### PR TITLE
🔥 lineprotocol, field value support list

### DIFF
--- a/models/points.go
+++ b/models/points.go
@@ -1176,6 +1176,8 @@ func scanLine(buf []byte, i int) (int, []byte) {
 	// this duplicates some of the functionality in scanFields
 	equals := 0
 	commas := 0
+	brackets := 0
+
 	for {
 		// reached the end of buf?
 		if i >= len(buf) {
@@ -1199,8 +1201,26 @@ func scanLine(buf []byte, i int) (int, []byte) {
 				equals++
 				continue
 			} else if !quoted && buf[i] == ',' {
+				// if , in list, ignore
+				if brackets == 0 {
+					commas++
+				}
 				i++
-				commas++
+				continue
+			} else if !quoted && buf[i] == '[' {
+				i++
+				brackets++
+				if brackets > 1 {
+					break
+				}
+				continue
+
+			} else if !quoted && buf[i] == ']' {
+				i++
+				brackets--
+				if brackets < 0 {
+					break
+				}
 				continue
 			} else if buf[i] == '"' && equals > commas {
 				i++

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -478,6 +478,15 @@ func test(t *testing.T, line string, point TestPoint) {
 	}
 }
 
+func TestParsePointFieldsContainsListAndNewLine(t *testing.T) {
+	lineStr := `m1,t1=v1 f1=["1","22"],f2="3\n4" 1709541240000000000`
+	_, err := models.ParsePointsString(lineStr)
+	if err != nil {
+		t.Errorf(`ParsePoints("%v") error`, err)
+	}
+	return
+}
+
 func TestParsePointNoValue(t *testing.T) {
 	pts, err := models.ParsePointsString("")
 	if err != nil {


### PR DESCRIPTION
行协议解析列表，bug修复


## 存在问题

之前函数 `scanLine` 没有考虑到, `field value` 满足下面两个条件，导致分割出 `line` 不正确

- [x] 包含 \n 

- [x] 等于号 > 逗号场景
 
 例如 
 
 ```
 m1,t1=v1 f1=["1","22"],f2="3
4" 1709541240000000000
 ```
 
 ## 修复方式
 
 添加 `brackets`，表示列表，当`,` 在列表中，不计算个数
 
 ## 测试
 
 添加测试函数 `TestParsePointFieldsContainsListAndNewLine`
 
 ```
➜  go test points_test.go
ok      command-line-arguments  0.969s

➜  go test -v points_test.go -run TestParsePointFieldsContainsListAndNewLine
=== RUN   TestParsePointFieldsContainsListAndNewLine
--- PASS: TestParsePointFieldsContainsListAndNewLine (0.00s)
PASS
ok      command-line-arguments  1.392s
```